### PR TITLE
Resolve image rendering issue

### DIFF
--- a/layouts/AuthorSingle.js
+++ b/layouts/AuthorSingle.js
@@ -21,8 +21,8 @@ const AuthorSingle = ({ frontmatter, content, mdxContent }) => {
                 <Image
                   src={image}
                   className="mx-auto rounded-lg"
-                  height="150"
-                  width="150"
+                  height={150}
+                  width={150}
                   alt={title}
                 />
               </div>

--- a/layouts/PostSingle.js
+++ b/layouts/PostSingle.js
@@ -66,8 +66,8 @@ const PostSingle = ({ post, posts, authors, slug }) => {
             {image && (
               <Image
                 src={image}
-                height="500"
-                width="1000"
+                height={500}
+                width={1000}
                 alt={title}
                 className="rounded-lg"
               />

--- a/layouts/partials/Authors.js
+++ b/layouts/partials/Authors.js
@@ -8,12 +8,12 @@ const Authors = ({ authors }) => {
       {authors.map((author, i) => (
         <div className="col-12 mb-8 sm:col-6 md:col-4" key={`key-${i}`}>
           {author.frontmatter.image && (
-            <div className="mb-4">
+            <div className="flex justify-center items-center mb-4">
               <Image
                 src={author.frontmatter.image}
                 alt={author.frontmatter.title}
-                height="150px"
-                width="150px"
+                height={150}
+                width={150}
                 className="rounded-lg"
               />
             </div>

--- a/layouts/partials/SimilarPosts.js
+++ b/layouts/partials/SimilarPosts.js
@@ -13,8 +13,8 @@ const SimilarPosts = ({ posts }) => {
               className="rounded-lg"
               src={post.frontmatter.image}
               alt={post.frontmatter.title}
-              width={"445"}
-              height={"230"}
+              width={445}
+              height={230}
             />
           )}
           <ul className="mt-4 text-text">


### PR DESCRIPTION
This PR addresses the Image component to ensure that images are rendered correctly. The latest versions of Next.js library requires the height and width properties to be passed as numeric values; therefore, they should be provided without quotation marks.

## Changes:

~ (Correction) Updated width and height properties to accept numerical values instead of strings.

~ (Improvement) Centered images within the div using the flex justify-center items-center classes.

Resolved the issue with the ```<Image />``` component.

![width={150}](https://github.com/themefisher/bookworm-light-nextjs/assets/56550632/9a9b38e3-382b-4df1-8435-8b1a54326068)